### PR TITLE
fix display of pallete colors to only use indexColors

### DIFF
--- a/js/view.js
+++ b/js/view.js
@@ -263,11 +263,9 @@ class ViewRender {
     this.activeLayer = tmpLayer;
 
     this._text('Pallete =', x, y, 'grey');
-    var pos = 0;
-    for (var c in this.pallete) {
-      this._text(pos.toString(16).toUpperCase(), pos + 10, y, pos == 0 ? 'grey' : 'black', this.pallete[c]);
-      pos++;
-    }
+    this.pallete.indexColors.forEach((name,index) => {
+      this._text(index.toString(16).toUpperCase(), index + 10, y, index === 0? 'grey' : 'black', this.pallete[name]);
+    })
     y+=2;
 
     for (let i = 0; i < help.length; i++) {


### PR DESCRIPTION
The released version uses all keys of pallete when displaying colors but the pallete object contains keys that are not colors (colors and indexColors). This results in extra non-colors being drawn. Additionally, when using for-in there is no guarantee of the order the keys will be iterated over but the order is clearly important. Since this fix iterates over pallete.indexColors it will always have the correct order.

A screenshot of the issue can be seen here: https://i.imgur.com/BIRNz0w.png